### PR TITLE
Users can't vote on IE11 and Edge 17 #17

### DIFF
--- a/src/main/resources/Ideas/IdeasClass.xml
+++ b/src/main/resources/Ideas/IdeasClass.xml
@@ -571,7 +571,7 @@
     });
     return false;
   }
-  $(window).on("load", function() {
+  $(document).ready(function() {
     $('.xvote-pro').click(function() {
       vote('voted-pro', 'voted-con', $(this));
     });


### PR DESCRIPTION
* there is no need to wait for a fully loaded DOM and $(document).ready is solving this issue since IE seems not to trigger $(window).onload event