### PR TITLE
Bug fix for issue#29: "ideas.home.title" remains in the Applications panel in a Subwiki after uninstalling

### DIFF
--- a/src/main/resources/Ideas/ApplicationsPanelEntry.xml
+++ b/src/main/resources/Ideas/ApplicationsPanelEntry.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.2" reference="Ideas.ApplicationsPanelEntry" locale="">
+  <web>Ideas</web>
+  <name>ApplicationsPanelEntry</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <creationDate>1561718991000</creationDate>
+  <parent>Ideas.WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <date>1561720764000</date>
+  <contentUpdateDate>1561720764000</contentUpdateDate>
+  <version>1.1</version>
+  <title>ApplicationsPanelEntry</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content/>
+  <object>
+    <name>Ideas.ApplicationsPanelEntry</name>
+    <number>0</number>
+    <className>XWiki.UIExtensionClass</className>
+    <guid>8a9b4db0-46b2-4fe4-aada-4f2769b8e1f8</guid>
+    <class>
+      <name>XWiki.UIExtensionClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <content>
+        <disabled>0</disabled>
+        <editor>Text</editor>
+        <name>content</name>
+        <number>3</number>
+        <prettyName>Extension Content</prettyName>
+        <rows>10</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </content>
+      <extensionPointId>
+        <disabled>0</disabled>
+        <name>extensionPointId</name>
+        <number>1</number>
+        <prettyName>Extension Point ID</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </extensionPointId>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>2</number>
+        <prettyName>Extension ID</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parameters>
+        <contenttype>PureText</contenttype>
+        <disabled>0</disabled>
+        <editor>PureText</editor>
+        <name>parameters</name>
+        <number>4</number>
+        <prettyName>Extension Parameters</prettyName>
+        <rows>10</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </parameters>
+      <scope>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>scope</name>
+        <number>5</number>
+        <prettyName>Extension Scope</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>wiki=Current Wiki|user=Current User|global=Global</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </scope>
+    </class>
+    <property>
+      <content/>
+    </property>
+    <property>
+      <extensionPointId>org.xwiki.platform.panels.Applications</extensionPointId>
+    </property>
+    <property>
+      <name>com.xwiki.ideas.IdeasApplication</name>
+    </property>
+    <property>
+      <parameters>label=$services.localization.render('ideas.app.title')
+target=Ideas.WebHome
+icon=icon:lightbulb</parameters>
+    </property>
+    <property>
+      <scope>global</scope>
+    </property>
+  </object>
+</xwikidoc>

--- a/src/main/resources/Ideas/WebHome.xml
+++ b/src/main/resources/Ideas/WebHome.xml
@@ -31,47 +31,21 @@
   <parent>Main.WebHome</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1561720875000</date>
-  <contentUpdateDate>1561720765000</contentUpdateDate>
+  <date>1561963639000</date>
+  <contentUpdateDate>1561963639000</contentUpdateDate>
   <version>1.1</version>
-  <title>$services.localization.render('platform.appwithinminutes.appHomePageTitle', $doc.space)</title>
+  <title>$services.localization.render('ideas.home.title')</title>
   <comment/>
   <minorEdit>false</minorEdit>
-  <syntaxId>xwiki/2.0</syntaxId>
+  <syntaxId>xwiki/2.1</syntaxId>
   <hidden>false</hidden>
-  <content>{{velocity}}
-$xwiki.jsx.use("Ideas.IdeasClass")
-$xwiki.ssx.use("Ideas.IdeasClass")
+  <content>{{include reference="Licenses.Code.VelocityMacros" /}}
 
-## Load the User Picker style for the "Assigned to" column
-#set($discard = $xwiki.ssfx.use('uicomponents/widgets/userpicker/userPicker.css'))
-
-#set ($columnsProperties = {
-  'nbvotes': {"type":"number","size":10,"html":true},
-  'nbagainst': {"type":"number","size":10,"html":true},
-  'nbestimate': {"type":"number","size":10,"html":true},
-  'doc.title': {"type":"text","size":20,"link":"view"},
-  'status': {"type":"list","size":20}, 
-  'priority': {"type":"list","size":20},
-  'assignement': {"type":"text","size":20,"link":"field", "html":true},
-  'doc.date': {"type":"text","size":10},
-  'doc.author': {"type":"text","size":10,"link":"author"},
-  '_actions': {"sortable":false,"filterable":false,"html":true,"actions":["edit","delete"]}
-})
-
-#set ($options = {
-  'className': 'Ideas.IdeasClass',
-  'translationPrefix': 'ideas.livetable.',
-  'tagCloud': true,
-  'rowCount': 15,
-  'maxPages': 10,
-  'selectedColumn': 'status',
-  'defaultOrder': 'asc',
-  'extraParams': '&amp;status=open'
-})
-
-#set ($columns = ['nbvotes','nbagainst','doc.title','nbestimate','status','priority','assignement','doc.date', 'doc.author', '_actions'])
-#livetable($doc $columns $columnsProperties $options)
+{{velocity}}
+#set ($mainPageReference = $services.model.createDocumentReference('', ['Ideas'], 'IdeasHomeSheet'))
+#if (!$services.licensing.licensor.hasLicensureForEntity($mainPageReference))
+  {{error}}#getMissingLicenseMessage('ideas.extension.name'){{/error}}
+#end
 {{/velocity}}</content>
   <class>
     <name>Ideas.WebHome</name>
@@ -150,7 +124,97 @@ $xwiki.ssx.use("Ideas.IdeasClass")
       </sheet>
     </class>
     <property>
-      <sheet>IdeasHomeSheet</sheet>
+      <sheet>Ideas.IdeasHomeSheet</sheet>
+    </property>
+  </object>
+  <object>
+    <name>Ideas.WebHome</name>
+    <number>0</number>
+    <className>XWiki.UIExtensionClass</className>
+    <guid>02520f39-a29e-4601-a678-cb75ada3d781</guid>
+    <class>
+      <name>XWiki.UIExtensionClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <content>
+        <disabled>0</disabled>
+        <editor>Text</editor>
+        <name>content</name>
+        <number>3</number>
+        <prettyName>Extension Content</prettyName>
+        <rows>10</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </content>
+      <extensionPointId>
+        <disabled>0</disabled>
+        <name>extensionPointId</name>
+        <number>1</number>
+        <prettyName>Extension Point ID</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </extensionPointId>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>2</number>
+        <prettyName>Extension ID</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parameters>
+        <contenttype>PureText</contenttype>
+        <disabled>0</disabled>
+        <editor>PureText</editor>
+        <name>parameters</name>
+        <number>4</number>
+        <prettyName>Extension Parameters</prettyName>
+        <rows>10</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </parameters>
+      <scope>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>scope</name>
+        <number>5</number>
+        <prettyName>Extension Scope</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>wiki=Current Wiki|user=Current User|global=Global</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </scope>
+    </class>
+    <property>
+      <content/>
+    </property>
+    <property>
+      <extensionPointId>org.xwiki.platform.panels.Applications</extensionPointId>
+    </property>
+    <property>
+      <name>com.xwiki.ideas.IdeasApplication</name>
+    </property>
+    <property>
+      <parameters>label=$services.localization.render('ideas.app.title')
+target=Ideas.WebHome
+icon=icon:lightbulb</parameters>
+    </property>
+    <property>
+      <scope>wiki</scope>
     </property>
   </object>
 </xwikidoc>

--- a/src/main/resources/Ideas/WebHome.xml
+++ b/src/main/resources/Ideas/WebHome.xml
@@ -20,28 +20,59 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc reference="Ideas.WebHome" locale="">
+<xwikidoc version="1.2" reference="Ideas.WebHome" locale="">
   <web>Ideas</web>
   <name>WebHome</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
-  <parent>Main.WebHome</parent>
   <creator>xwiki:XWiki.Admin</creator>
-  <author>xwiki:XWiki.Admin</author>
-  <customClass/>
-  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
   <creationDate>1374503492000</creationDate>
-  <date>1512394929000</date>
-  <contentUpdateDate>1512394929000</contentUpdateDate>
+  <parent>Main.WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <date>1561720875000</date>
+  <contentUpdateDate>1561720765000</contentUpdateDate>
   <version>1.1</version>
-  <title>$services.localization.render('ideas.home.title')</title>
-  <defaultTemplate/>
-  <validationScript/>
+  <title>$services.localization.render('platform.appwithinminutes.appHomePageTitle', $doc.space)</title>
   <comment/>
   <minorEdit>false</minorEdit>
-  <syntaxId>xwiki/2.1</syntaxId>
+  <syntaxId>xwiki/2.0</syntaxId>
   <hidden>false</hidden>
+  <content>{{velocity}}
+$xwiki.jsx.use("Ideas.IdeasClass")
+$xwiki.ssx.use("Ideas.IdeasClass")
+
+## Load the User Picker style for the "Assigned to" column
+#set($discard = $xwiki.ssfx.use('uicomponents/widgets/userpicker/userPicker.css'))
+
+#set ($columnsProperties = {
+  'nbvotes': {"type":"number","size":10,"html":true},
+  'nbagainst': {"type":"number","size":10,"html":true},
+  'nbestimate': {"type":"number","size":10,"html":true},
+  'doc.title': {"type":"text","size":20,"link":"view"},
+  'status': {"type":"list","size":20}, 
+  'priority': {"type":"list","size":20},
+  'assignement': {"type":"text","size":20,"link":"field", "html":true},
+  'doc.date': {"type":"text","size":10},
+  'doc.author': {"type":"text","size":10,"link":"author"},
+  '_actions': {"sortable":false,"filterable":false,"html":true,"actions":["edit","delete"]}
+})
+
+#set ($options = {
+  'className': 'Ideas.IdeasClass',
+  'translationPrefix': 'ideas.livetable.',
+  'tagCloud': true,
+  'rowCount': 15,
+  'maxPages': 10,
+  'selectedColumn': 'status',
+  'defaultOrder': 'asc',
+  'extraParams': '&amp;status=open'
+})
+
+#set ($columns = ['nbvotes','nbagainst','doc.title','nbestimate','status','priority','assignement','doc.date', 'doc.author', '_actions'])
+#livetable($doc $columns $columnsProperties $options)
+{{/velocity}}</content>
   <class>
     <name>Ideas.WebHome</name>
     <customClass/>
@@ -118,110 +149,8 @@
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </sheet>
     </class>
-    <name>Ideas.WebHome</name>
-    <number>0</number>
-    <className>XWiki.DocumentSheetBinding</className>
-    <guid>756e1529-9f18-4765-a817-97ce7b08c152</guid>
     <property>
-      <sheet>Ideas.IdeasHomeSheet</sheet>
+      <sheet>IdeasHomeSheet</sheet>
     </property>
   </object>
-  <object>
-    <class>
-      <name>XWiki.UIExtensionClass</name>
-      <customClass/>
-      <customMapping/>
-      <defaultViewSheet/>
-      <defaultEditSheet/>
-      <defaultWeb/>
-      <nameField/>
-      <validationScript/>
-      <content>
-        <disabled>0</disabled>
-        <editor>Text</editor>
-        <name>content</name>
-        <number>3</number>
-        <prettyName>Extension Content</prettyName>
-        <rows>10</rows>
-        <size>40</size>
-        <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
-      </content>
-      <extensionPointId>
-        <disabled>0</disabled>
-        <name>extensionPointId</name>
-        <number>1</number>
-        <prettyName>Extension Point ID</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </extensionPointId>
-      <name>
-        <disabled>0</disabled>
-        <name>name</name>
-        <number>2</number>
-        <prettyName>Extension ID</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </name>
-      <parameters>
-        <contenttype>PureText</contenttype>
-        <disabled>0</disabled>
-        <editor>PureText</editor>
-        <name>parameters</name>
-        <number>4</number>
-        <prettyName>Extension Parameters</prettyName>
-        <rows>10</rows>
-        <size>40</size>
-        <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
-      </parameters>
-      <scope>
-        <cache>0</cache>
-        <disabled>0</disabled>
-        <displayType>select</displayType>
-        <multiSelect>0</multiSelect>
-        <name>scope</name>
-        <number>5</number>
-        <prettyName>Extension Scope</prettyName>
-        <relationalStorage>0</relationalStorage>
-        <separator> </separator>
-        <separators>|, </separators>
-        <size>1</size>
-        <unmodifiable>0</unmodifiable>
-        <values>wiki=Current Wiki|user=Current User|global=Global</values>
-        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
-      </scope>
-    </class>
-    <name>Ideas.WebHome</name>
-    <number>0</number>
-    <className>XWiki.UIExtensionClass</className>
-    <guid>02520f39-a29e-4601-a678-cb75ada3d781</guid>
-    <property>
-      <content/>
-    </property>
-    <property>
-      <extensionPointId>org.xwiki.platform.panels.Applications</extensionPointId>
-    </property>
-    <property>
-      <name>com.xwiki.ideas.IdeasApplication</name>
-    </property>
-    <property>
-      <parameters>label=$services.localization.render('ideas.app.title')
-target=Ideas.WebHome
-icon=icon:lightbulb</parameters>
-    </property>
-    <property>
-      <scope>wiki</scope>
-    </property>
-  </object>
-  <content>{{include reference="Licenses.Code.VelocityMacros" /}}
-
-{{velocity}}
-#set ($mainPageReference = $services.model.createDocumentReference('', ['Ideas'], 'IdeasHomeSheet'))
-#if (!$services.licensing.licensor.hasLicensureForEntity($mainPageReference))
-  {{error}}#getMissingLicenseMessage('ideas.extension.name'){{/error}}
-#end
-{{/velocity}}</content>
 </xwikidoc>


### PR DESCRIPTION
Deleted the UIExtension object from WebHome & integrated it in another page, so that it'll be included on the list of pages that will be deleted.