### PR TITLE
#40 : When installing the ideas application on a subwiki, the application panel entry is shown on the whole farm

### DIFF
--- a/src/main/resources/Ideas/ApplicationsPanelEntry.xml
+++ b/src/main/resources/Ideas/ApplicationsPanelEntry.xml
@@ -127,7 +127,7 @@ target=Ideas.WebHome
 icon=icon:lightbulb</parameters>
     </property>
     <property>
-      <scope>global</scope>
+      <scope>wiki</scope>
     </property>
   </object>
 </xwikidoc>


### PR DESCRIPTION
* limit the scope of the applications panel entry to WIKI instead of
  GLOBAL