### PR TITLE
Voting buttons are not updating in realtime #74

### DIFF
--- a/application-ideas-api/src/main/java/com/xwiki/ideas/internal/DefaultIdeasManager.java
+++ b/application-ideas-api/src/main/java/com/xwiki/ideas/internal/DefaultIdeasManager.java
@@ -205,11 +205,9 @@ public class DefaultIdeasManager implements IdeasManager
                 } else {
                     againstAction.perform(ideasObj, serializedUser, xcontext);
                 }
-                Idea result = get(documentReference);
-
                 // Save document
                 xWiki.saveDocument(ideasDoc, "Updated Votes", xcontext);
-                return result;
+                return get(documentReference);
             } else {
                 throw new IdeasException(String.format(NOT_FOUND_ERROR, documentReference));
             }

--- a/application-ideas-api/src/main/java/com/xwiki/ideas/internal/DefaultIdeasManager.java
+++ b/application-ideas-api/src/main/java/com/xwiki/ideas/internal/DefaultIdeasManager.java
@@ -190,7 +190,7 @@ public class DefaultIdeasManager implements IdeasManager
         XWikiContext xcontext = contextProvider.get();
         XWiki xWiki = xcontext.getWiki();
         try {
-            XWikiDocument ideasDoc = xWiki.getDocument(documentReference, xcontext);
+            XWikiDocument ideasDoc = xWiki.getDocument(documentReference, xcontext).clone();
 
             BaseObject ideasObj = ideasDoc.getXObject(IDEA_CLASS_REFERENCE);
             DocumentReference user = xcontext.getUserReference();


### PR DESCRIPTION
# Issue URL

Fixes #74 

# Changes

* Fix the idea vote counter in new versions of XWiki (save document _before_ returning the vote count)
* Fix an 'Abusive modification of the cached document' error by copying the fix from [here](https://github.com/xwiki-contrib/application-discussions/commit/fa45128eeafdf4a1a00312967838b6f382cbfaac).

# Executed Tests

Manual & Automated

* [ ] I checked the accessibility of this change (if you don't know what this is about or how to do it, leave this unchecked and don't worry)

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
